### PR TITLE
Remove container name from compose services

### DIFF
--- a/common/caddy/docker-compose.yaml
+++ b/common/caddy/docker-compose.yaml
@@ -5,7 +5,6 @@ volumes:
 services:
   caddy:
     image: caddy:2.8
-    container_name: caddy
     restart: always
     cap_add:
       - NET_ADMIN

--- a/common/environment/docker-compose.yaml
+++ b/common/environment/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: environment
     restart: always
     environment:
       VAULT_USERNAME: ${ENVIRONMENT_USERNAME:?ENVIRONMENT_USERNAME is not set}

--- a/common/minio/docker-compose.yaml
+++ b/common/minio/docker-compose.yaml
@@ -3,7 +3,6 @@ volumes:
 
 services:
   minio:
-    container_name: minio
     image: minio/minio
     restart: always
     volumes:
@@ -15,7 +14,6 @@ services:
 
   minio_helper:
     image: minio/mc
-    container_name: minio-helper
     profiles: ["minio"]
     volumes:
       - './kickstart.sh:/etc/minio/kickstart.sh'

--- a/common/monitoring/docker-compose.yaml
+++ b/common/monitoring/docker-compose.yaml
@@ -7,7 +7,6 @@ volumes:
 services:
   loki:
     image: grafana/loki:2.9.5
-    container_name: loki
     restart: always
     depends_on:
       - minio
@@ -23,7 +22,6 @@ services:
 
   promtail:
     image: grafana/promtail:2.9.5 
-    container_name: promtail
     restart: always
     volumes:
       - '/var/lib/docker/containers:/var/lib/docker/containers:ro'
@@ -32,7 +30,6 @@ services:
 
   grafana:
     image: grafana/grafana:10.3.4
-    container_name: grafana
     restart: always
     depends_on:
       - promtail
@@ -52,7 +49,6 @@ services:
 
   node_exporter:
     image: prom/node-exporter:v1.6.1
-    container_name: node-exporter
     hostname: ${org}-${env}
     restart: always
     volumes:
@@ -68,7 +64,6 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.50.1
-    container_name: prometheus
     restart: always
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
@@ -86,7 +81,6 @@ services:
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1 
-    container_name: cadvisor
     restart: always
     privileged: true
     volumes:
@@ -99,7 +93,6 @@ services:
       - /dev/kmsg:/dev/kmsg
 
   status:
-    container_name: status
     image: louislam/uptime-kuma:1
     restart: always
     volumes:

--- a/common/monitoring/grafana/dashboards/prometheus-dashboard.json
+++ b/common/monitoring/grafana/dashboards/prometheus-dashboard.json
@@ -23803,8 +23803,8 @@
       {
         "current": {
           "selected": false,
-          "text": "node-exporter:9100",
-          "value": "node-exporter:9100"
+          "text": "node_exporter:9100",
+          "value": "node_exporter:9100"
         },
         "datasource": {
           "type": "prometheus",

--- a/common/monitoring/prometheus/prometheus.yaml
+++ b/common/monitoring/prometheus/prometheus.yaml
@@ -5,7 +5,7 @@ scrape_configs:
   - job_name: 'node'
     scrape_interval: 5s
     static_configs:
-      - targets: ['node-exporter:9100']
+      - targets: ['node_exporter:9100']
   - job_name: 'cadvisor'
     scrape_interval: 5s
     static_configs:


### PR DESCRIPTION
Using container_name has a downside that when we try to run replicas using docker inbuilt `replicas` keyword, the service fails to start as unique container name is needed for each replica.

Reference: https://stackoverflow.com/a/71829251