### PR TITLE
fix: add missing template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/.env*
-**/env.*
+**/env.tmp
 deploy.log
 scripts/webhook/hooks.json

--- a/common/environment/env.tpl
+++ b/common/environment/env.tpl
@@ -1,0 +1,2 @@
+{{ range secrets "kv/" }} {{ with secret (printf "kv/%s" .) }} {{ range $k, $v := .Data.data }} 
+{{ printf "%s='%s'" $k $v | trimSpace }}{{ end }}{{ end }}{{ end }}


### PR DESCRIPTION
`2024-06-06T11:25:33.822Z [ERR] (cli) failed to read template: open env.tpl: no such file or directory`
due to .gitignore rule env.tpl was missed during commit 