### PR TITLE
fix: make the backup of the last Consul file optional

### DIFF
--- a/common/environment/consul-init.sh
+++ b/common/environment/consul-init.sh
@@ -19,7 +19,10 @@ if ! vault kv get kv/env >/dev/null 2>&1; then
 # create a backup of the original .env
 cp .env .env.bak
 else 
-mv env.tmp .env.back
+  # Backup the last file created by Consul 
+  if [ -f env.tmp ]; then
+      mv env.tmp .env.back
+  fi
 fi
 
 


### PR DESCRIPTION
Current implementation fails when `env.tmp` is not preset 